### PR TITLE
feat: Sandbox CPU timeout

### DIFF
--- a/src/Runner/init.lua
+++ b/src/Runner/init.lua
@@ -13,7 +13,7 @@ return (function(Runner)
 				callback = sandbox:LoadFunction(callback)
 
 				if sandbox.Terminated then
-					return sandbox:CheckTermination()
+					return
 				end
 			else
 				--if WARN_UNSANDBOXED_RUNNER then

--- a/src/Runner/init.lua
+++ b/src/Runner/init.lua
@@ -25,7 +25,7 @@ return (function(Runner)
 			local scriptObject = self.ScriptObject
 			if scriptObject:IsA("BaseScript") then
 				if scriptObject.Disabled then
-					return error("The runner script is disabled so code cannot be executed", 2)
+					return error("Runner script is disabled", 2)
 				end
 			end
 

--- a/src/Sandbox/Sandbox.lua
+++ b/src/Sandbox/Sandbox.lua
@@ -98,7 +98,7 @@ function Sandbox.new(options)
 		},
 		ImportMetatable = {
 			__call = function(object, ...)
-				self:CheckTermination()
+				self:ProcessTermination()
 				self:TrackThread()
 				local real = self:GetClean(object)
 
@@ -111,7 +111,7 @@ function Sandbox.new(options)
 				return table.unpack(results, 1, results.n)
 			end,
 			__index = function(object, index)
-				self:CheckTermination()
+				self:ProcessTermination()
 				self:TrackThread()
 
 				local real = self:GetClean(object)
@@ -121,7 +121,7 @@ function Sandbox.new(options)
 				return self:Import(value)
 			end,
 			__newindex = function(object, index, value)
-				self:CheckTermination()
+				self:ProcessTermination()
 				self:TrackThread()
 				index = self:GetClean(index)
 				value = self:GetClean(value)
@@ -132,7 +132,7 @@ function Sandbox.new(options)
 				self:ActivityEvent("Set", real, index, value)
 			end,
 			__iter = function(object)
-				self:CheckTermination()
+				self:ProcessTermination()
 				self:TrackThread()
 
 				local real = self:GetClean(object)
@@ -153,7 +153,7 @@ function Sandbox.new(options)
 		},
 		ExportMetatable = {
 			__call = function(object, ...)
-				self:CheckTermination()
+				self:ProcessTermination()
 				local real = self:GetClean(object)
 
 				local results = if Util.isCFunction(real) then
@@ -165,7 +165,7 @@ function Sandbox.new(options)
 				return table.unpack(results, 1, results.n)
 			end,
 			__index = function(object, index)
-				self:CheckTermination()
+				self:ProcessTermination()
 				index = self:GetClean(index)
 
 				local real = self:GetClean(object)
@@ -175,7 +175,7 @@ function Sandbox.new(options)
 				return self:Export(value)
 			end,
 			__newindex = function(object, index, value)
-				self:CheckTermination()
+				self:ProcessTermination()
 				index = self:GetClean(index)
 				value = self:GetClean(value)
 
@@ -185,7 +185,7 @@ function Sandbox.new(options)
 				self:ActivityEvent("Set", real, index, value)
 			end,
 			__iter = function(object)
-				self:CheckTermination()
+				self:ProcessTermination()
 				self:TrackThread()
 
 				local real = self:GetClean(object)

--- a/src/Sandbox/Sandbox.lua
+++ b/src/Sandbox/Sandbox.lua
@@ -223,6 +223,8 @@ function Sandbox.new(options)
 	self:AddDefaultSecurityRules()
 	self:AddDefaultRedirects()
 
+	self:ResetTimers()
+
 	return self
 end
 

--- a/src/Sandbox/init.lua
+++ b/src/Sandbox/init.lua
@@ -553,6 +553,16 @@ function Sandbox:Terminate(terminateCaller: boolean?)
 	for _, thread in ipairs(threads) do
 		killThread(thread)
 	end
+--[=[
+	Do not call this function.
+	This function is called automatically when code inside the sandbox triggers any managed code.
+	It is used to determine if the sandbox needs to terminate/has terminated, and if so, will cease execution immediately.
+]=]
+function Sandbox:ProcessTermination()
+	if self.Terminated then
+		self:Terminate(true)
+	end
+end
 
 	-- Remove tracked values
 	self.Tracked = nil

--- a/src/Sandbox/init.lua
+++ b/src/Sandbox/init.lua
@@ -503,7 +503,7 @@ end
 local function killThread(thread): boolean
 	local status = coroutine.status(thread)
 	if status ~= "dead" then
-		if status == "suspended" then
+		if status == "suspended" or status == "normal" then
 			-- Close the thread
 			coroutine.close(thread)
 		elseif status ~= "running" then

--- a/src/Tests/H6x/Terminate/Timeout/MultiThread.lua
+++ b/src/Tests/H6x/Terminate/Timeout/MultiThread.lua
@@ -1,0 +1,26 @@
+return function(H6x)
+	local sandbox = H6x.Sandbox.new()
+
+	local FAILED = false
+	sandbox:SetTimeout(0.05)
+	local depth = 0
+	task.defer(function(thread)
+		pcall(function()
+			sandbox:ExecuteFunction(function()
+				local startTime = os.clock()
+				local function hangForAWhile()
+					depth += 1
+					task.wait()
+					task.spawn(pcall, hangForAWhile)
+					-- Note: Managed code is triggered by os.clock()
+					while os.clock() - startTime < (sandbox.Timeout * 2 + 0.5) do end
+					FAILED = true
+				end
+				task.spawn(pcall, hangForAWhile)
+			end)
+		end)
+		coroutine.resume(thread)
+	end, coroutine.running())
+	coroutine.yield() -- Wait until the above completes
+	assert(not FAILED, "Sandbox didn't terminate after the configured timeout.")
+end

--- a/src/Tests/H6x/Terminate/Timeout/SingleThread.lua
+++ b/src/Tests/H6x/Terminate/Timeout/SingleThread.lua
@@ -1,0 +1,15 @@
+return function(H6x)
+	local sandbox = H6x.Sandbox.new()
+
+	local FAILED = false
+	sandbox:SetTimeout(0.05)
+	task.spawn(pcall, function()
+		sandbox:ExecuteFunction(function()
+			local startTime = os.clock()
+			-- Note: Managed code is triggered by os.clock()
+			while os.clock() - startTime < (sandbox.Timeout * 2 + 0.5) do end
+			FAILED = true
+		end)
+	end)
+	assert(not FAILED, "Sandbox didn't terminate after the configured timeout.")
+end


### PR DESCRIPTION
Adds some APIs for measuring and limiting the CPU usage of sandboxed code:
`Sandbox:GetCPUTimeNow()` - Returns the number of seconds of CPU time the sandbox has used. You can use this to measure performance.
`Sandbox:SetTimeout(seconds)` - From the point of calling, the sandbox will be terminated if it runs for more than this length of time. If seconds is `nil` or `0` removes any active timeout. Note that time spent yielding to other non-executing code is **not** counted as it has no performance implications. (E.g. `task.wait(1)` does not have a CPU time of `1`, it has a CPU time of approximately however long it took to schedule the wait)

Additionally makes some minor improvements to thread termination. Terminations of various more complex situations are handled better without warnings or errors in the output. Additionally sandboxed code is terminated a little more aggressively in some cases where it was not previously, reducing the potential amount of CPU time a sandbox could waste if it desired to waste CPU.