### PR TITLE
Fix callable userdata support

### DIFF
--- a/src/SandboxActivity.lua
+++ b/src/SandboxActivity.lua
@@ -28,7 +28,7 @@ return (function(SandboxActivity)
 					local activity = self.Activity
 					local Name = activity.Name
 
-					local nargs, varArg, name, source = debug.info(func, "ans")
+					local nargs, varArg, name, source = if type(func) == "function" then debug.info(func, "ans") else nil, nil, nil, nil
 
 					-- Track the called function's name
 					-- Name:Track(func, name)

--- a/src/Tests/H6x/Management/CallableUserdata.lua
+++ b/src/Tests/H6x/Management/CallableUserdata.lua
@@ -1,0 +1,25 @@
+return function(H6x)
+	local sandbox = H6x.Sandbox.new()
+
+	local userdata = newproxy(true)
+	local metatable = getmetatable(userdata)
+
+	-- Ensure that calling userdatas works as intended
+	metatable.__call = function(self, arg)
+		return arg
+	end
+	assert(sandbox:ExecuteFunction(function(userdata)
+		return userdata(123)
+	end, userdata) == 123, "Called userdata did not return correct results.")
+
+	-- Ensure that the sandbox cannot circumvent sandbox rules
+	metatable.__call = function()
+		return game
+	end
+	sandbox:ExecuteFunction(function(userdata)
+		assert(not userdata(), "Sandbox accessed disallowed object from callable userdata.")
+	end, userdata)
+
+	-- Ensure activity logging works as expected
+	H6x.Logger:Debug(sandbox:GenerateActivityReport("h6x"))
+end

--- a/src/Util.lua
+++ b/src/Util.lua
@@ -10,6 +10,10 @@ function Util.copy(tab)
 	return copy
 end
 function Util.isCFunction(func)
+	if type(func) ~= "function" then
+		return false
+	end
+
 	local source, line = debug.info(func, "sl")
 	return source == "[C]" and line == -1
 end

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hexcede/h6x"
 description = "A luau utility for constructing sandboxes to run code within."
-version = "2.1.0"
+version = "2.1.1"
 license = "MIT"
 authors = ["Hexcede"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Add type checking for `isCFunction` helper and call logging, and support callable userdatas.

Called userdatas are now treated as non-c functions (lua managed code) which results in better security at the potential downfall of having compatability issues with Roblox features. As far as I'm aware though, Roblox does not provide any callable userdatas.

---

I would also like to make a technical note (mostly for myself in the future and anyone curious)

In the future this may be changed (callable userdatas could be treated as a non-lua function), as sandboxed code can't actually construct a callable userdata without invoking the sandbox with their function body, making this perfectly safe in comparison to other features:
```lua
local userdata = newproxy(true) -- newproxy is managed (returns managed userdata)
local metatable = getmetatable(userdata) -- getmetatable and userdata are managed (returns managed table)
metatable.__call = function() -- __call is set on the managed metatable, meaning the lua function being set here is also managed
	-- remains managed
end
userdata()
```

Making callable userdatas considered non-lua functions is almost identical in its attack surface to `coroutine.wrap` and has pretty much exactly the same nuances to it, so it would result in the same kinds of theoretical sandbox exploits, which don't really pose a risk.
```lua
local func = coroutine.wrap(function() -- coroutine.wrap is managed
	-- remains managed
end)
-- even though the wrapped function is classified as a C function, the body remains managed by the sandbox because it must first pass through coroutine.wrap (just like any other function accepting functions)
func()
```

C functions will not accept values proxied by `H6x` (e.g. functions accepting `Instance`s) and they typically don't abide by metatables. Lua code is physically incapable of taking advantage of this on its own, the only cases where this would matter involves what sandboxed code can do without touching the global environment or anything in it, so effectively special syntax which is occasionally added but typically does not have any effects (e.g. `__iter`).

However, aside from it being perfectly fine to do this, currently I just see no potential compatibility issues arising by simply making the assumption that callable userdatas will only ever be created by external lua code.

---

Fixes #16 