### PR TITLE
Hotfix #20 - __len metamethod changes

### DIFF
--- a/src/Reflector.lua
+++ b/src/Reflector.lua
@@ -50,9 +50,10 @@ end
 function Reflector:__le(real, value)
 	return real <= value
 end
-function Reflector:__len(real)
-	return #real
-end
+-- TODO: Re-implement properly (Breaks H6x with new __len changes)
+-- function Reflector:__len(real)
+-- 	return #real
+-- end
 
 function Reflector.new(real, sandbox)
 	local self = {}

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hexcede/h6x"
 description = "A luau utility for constructing sandboxes to run code within."
-version = "2.1.1"
+version = "2.1.2"
 license = "MIT"
 authors = ["Hexcede"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Remove __len proxying from the Reflector. This causes a stack overflow on proxied tables due to the new __len changes. Later, should re-implement this.

Fixes #20 